### PR TITLE
Make read behavior more explicit and test it

### DIFF
--- a/taggedartifacts/taggedartifacts.py
+++ b/taggedartifacts/taggedartifacts.py
@@ -16,10 +16,10 @@ class Artifact(object):
         self.is_dirty = self.repo.diff().stats.files_changed > 0
         if self.is_dirty and self.allow_dirty:
             logger.warn('Repository has unstaged changes. '
-                        'Creating artifacts, but marking them dirty.')
+                        'Creating or reading artifacts, but I make no promises.')
         elif self.is_dirty:
             raise OSError(
-                'Refusing to create artifacts with a dirty repository.')
+                'Refusing to create or read artifacts with a dirty repository.')
 
         self.commitish = str(self.repo.head.resolve().target)[:7] + (
             '-dirty' if self.is_dirty else '')

--- a/taggedartifacts/taggedartifacts.py
+++ b/taggedartifacts/taggedartifacts.py
@@ -16,10 +16,10 @@ class Artifact(object):
         self.is_dirty = self.repo.diff().stats.files_changed > 0
         if self.is_dirty and self.allow_dirty:
             logger.warn('Repository has unstaged changes. '
-                        'Creating or reading artifacts, but I make no promises.')
+                        'Creating or reading artifacts anyway.')
         elif self.is_dirty:
             raise OSError(
-                'Refusing to create or read artifacts with a dirty repository.')
+                'Refusing to do any work with a dirty repository.')
 
         self.commitish = str(self.repo.head.resolve().target)[:7] + (
             '-dirty' if self.is_dirty else '')

--- a/tests/test_taggedartifacts.py
+++ b/tests/test_taggedartifacts.py
@@ -21,6 +21,11 @@ def func2(outpath):
     with open(outpath, 'w') as outf:
         outf.write('good job')
 
+@Artifact('inpath')
+def func_read(inpath):
+    with open(inpath, 'r') as inf:
+        return inf.read()
+
 
 class TestTaggedArtifacts(unittest.TestCase):
     """Tests for `taggedartifacts` package."""
@@ -35,11 +40,13 @@ class TestTaggedArtifacts(unittest.TestCase):
         for f in files:
             os.remove(f)
 
-    def test_create_file(self):
+    def test_pipeline(self):
         func(outpath='foo.txt')
         files = glob.glob('foo*.txt')
         assert len(files) == 1
         assert 'foo.txt' not in files
+        read = func_read(inpath='foo.txt')
+        assert read == 'good job'
 
     def test_assert_for_bad_keyword(self):
         with self.assertRaises(KeyError):


### PR DESCRIPTION
Overview
-----

This PR makes pipeline behavior more obvious in tests, where even though no file named `foo.txt` exists, we can still decorate with `Artifact(keyword)` and thread things through.